### PR TITLE
fix: Theme 분리 대응

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -137,10 +137,7 @@
         <resource-file src="src/android/Library/res/layout/actionbar_done_button.xml" target="res/layout/actionbar_done_button.xml"/>
         <resource-file src="src/android/Library/res/layout/multiselectorgrid.xml" target="res/layout/multiselectorgrid.xml"/>
         <resource-file src="src/android/Library/res/values/multiimagechooser_strings_en.xml" target="res/values/multiimagechooser_strings_en.xml"/>
-        <config-file target="res/values/themes.xml" parent="/resources">
-            <style name="MyTheme" parent="android:Theme.Holo.Light">
-            </style>
-        </config-file>
+        <resource-file src="src/android/Library/res/values/themes.xml" target="res/values/themes.xml"/>
         <resource-file src="src/android/Library/res/values-de/multiimagechooser_strings_de.xml" target="res/values-de/multiimagechooser_strings_de.xml"/>
         <resource-file src="src/android/Library/res/values-es/multiimagechooser_strings_es.xml" target="res/values-es/multiimagechooser_strings_es.xml"/>
         <resource-file src="src/android/Library/res/values-fr/multiimagechooser_strings_fr.xml" target="res/values-fr/multiimagechooser_strings_fr.xml"/>

--- a/plugin.xml
+++ b/plugin.xml
@@ -137,7 +137,7 @@
         <resource-file src="src/android/Library/res/layout/actionbar_done_button.xml" target="res/layout/actionbar_done_button.xml"/>
         <resource-file src="src/android/Library/res/layout/multiselectorgrid.xml" target="res/layout/multiselectorgrid.xml"/>
         <resource-file src="src/android/Library/res/values/multiimagechooser_strings_en.xml" target="res/values/multiimagechooser_strings_en.xml"/>
-        <resource-file src="src/android/Library/res/values/themes.xml" target="res/values/themes.xml"/>
+        <resource-file src="src/android/Library/res/values/multiimageThemes.xml" target="res/values/multiimageThemes.xml"/>
         <resource-file src="src/android/Library/res/values-de/multiimagechooser_strings_de.xml" target="res/values-de/multiimagechooser_strings_de.xml"/>
         <resource-file src="src/android/Library/res/values-es/multiimagechooser_strings_es.xml" target="res/values-es/multiimagechooser_strings_es.xml"/>
         <resource-file src="src/android/Library/res/values-fr/multiimagechooser_strings_fr.xml" target="res/values-fr/multiimagechooser_strings_fr.xml"/>

--- a/src/android/Library/res/values/multiimageThemes.xml
+++ b/src/android/Library/res/values/multiimageThemes.xml
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources>
-    <!-- [임의 수정][Android] jmhur : PickVisualMedia 팝업의 백그라운드를 투명처리 하기 위한 theme -->
     <style name="TransparentTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <item name="android:windowBackground">@android:color/transparent</item>
         <item name="android:windowIsTranslucent">true</item>

--- a/src/android/Library/res/values/themes.xml
+++ b/src/android/Library/res/values/themes.xml
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='utf-8'?>
+<resources>
+    <!-- [임의 수정][Android] jmhur : PickVisualMedia 팝업의 백그라운드를 투명처리 하기 위한 theme -->
+    <style name="TransparentTheme" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowNoTitle">true</item>
+    </style>
+</resources>


### PR DESCRIPTION
### 이슈
- 상황: 그동안 imagePicker theme을 res folder에 추가해놓아서, 새로 install시 기존 데이터가 날아가는 이슈가 있었음, plugin 소스파일에 추가하여 코드가 누락되는 상황 방지
- 원인: res folder에 직접 추가된 theme 데이터
- PR 중요도 : 🟠 중요
- PR 기한: 2월 5일 수요일
- 배포예정일: -
- 링크: -

### 작업내용
- multiimageThemes 추가
- 사용하지 않는 태그 삭제