### PR TITLE
fix: 권한대응 qa 2차

### DIFF
--- a/src/android/Library/src/MultiImageChooserActivity.java
+++ b/src/android/Library/src/MultiImageChooserActivity.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.ContentResolver;
+import android.util.Log;
 
 import android.net.Uri;
 import android.os.Bundle;
@@ -42,7 +43,13 @@ public class MultiImageChooserActivity extends AppCompatActivity {
                         ArrayList<String> stringList = new ArrayList<>();
                         for (Uri uri : uris) {
                             stringList.add(uri.toString());
-                            contentResolver.takePersistableUriPermission(uri, flag);
+                            try {
+                                contentResolver.takePersistableUriPermission(uri, flag);
+                            } catch (SecurityException e) {
+                                Log.e("PickMedia", "Failed to take persistable URI permission: " +
+                                        e.getMessage());
+                            }
+
                         }
                         postImages(stringList);
                     } else {

--- a/src/android/com/synconset/ImagePicker/ImagePicker.java
+++ b/src/android/com/synconset/ImagePicker/ImagePicker.java
@@ -52,13 +52,31 @@ public class ImagePicker extends CordovaPlugin {
             throws JSONException {
         this.callbackContext = callbackContext;
 
-        if (ACTION_GET_PICTURES.equals(action)) {
+        if (ACTION_HAS_READ_PERMISSION.equals(action)) {
+            callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, hasReadPermission()));
+            return true;
+
+        } else if (ACTION_REQUEST_READ_PERMISSION.equals(action)) {
+            requestReadPermission();
+            return true;
+
+        } else if (ACTION_GET_PICTURES.equals(action)) {
             final JSONObject params = args.getJSONObject(0);
             imagePickerIntent = getImagePickerIntent(params);
-            cordova.startActivityForResult(this, imagePickerIntent, 0);
+
+            if (hasReadPermission()) {
+                cordova.startActivityForResult(this, imagePickerIntent, 0);
+            } else {
+                if (getPreference(PERMISSION_REQUESTED) == false) {
+                    requestReadPermission();
+                    // callbackContext.success();
+                } else {
+                    callbackContext
+                            .error("저장소 접근이 제한되었습니다. [설정 > 앱 > " + getApplicationName() + "]에서 저장소 접근 권한을 허용해 주세요.");
+                }
+            }
             return true;
         }
-
         return false;
     }
 
@@ -106,6 +124,27 @@ public class ImagePicker extends CordovaPlugin {
         return imagePickerIntent;
     }
 
+    @SuppressLint("InlinedApi")
+    private boolean hasReadPermission() {
+        String permission = Manifest.permission.READ_EXTERNAL_STORAGE;
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q) {
+            return cordova.hasPermission(permission);
+        }
+        return true;
+    }
+
+    @SuppressLint("InlinedApi")
+    private void requestReadPermission() {
+        if (!hasReadPermission()) {
+            String[] permissions = { Manifest.permission.READ_EXTERNAL_STORAGE };
+
+            setPreference(PERMISSION_REQUESTED, true);
+            cordova.requestPermissions(this,
+                    PERMISSION_REQUEST_CODE,
+                    permissions);
+        }
+    }
+
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         if (resultCode == Activity.RESULT_OK && data != null) {
             int sync = data.getIntExtra("bigdata:synccode", -1);
@@ -129,11 +168,36 @@ public class ImagePicker extends CordovaPlugin {
         }
     }
 
+    /**
+     * Choosing a picture launches another Activity, so we need to implement the
+     * save/restore APIs to handle the case where the CordovaActivity is killed by
+     * the OS
+     * before we get the launched Activity's result.
+     *
+     * @see ://cordova.apache.org/docs/en/dev/guide/platforms/android/plugin.html#launching-other-activities
+     */
+    public void onRestoreStateForActivityResult(Bundle state, CallbackContext callbackContext) {
+        this.callbackContext = callbackContext;
+    }
+
+    @Override
+    public void onRequestPermissionResult(int requestCode,
+            String[] permissions,
+            int[] grantResults) throws JSONException {
+
+        // For now we just have one permission, so things can be kept simple...
+        if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+            cordova.startActivityForResult(this, imagePickerIntent, 0);
+        } else {
+            // Tell the JS layer that something went wrong...
+            callbackContext.error("저장소 접근이 제한되었습니다. [설정 > 앱 > " + getApplicationName() + "]에서 저장소 접근 권한을 허용해 주세요");
+        }
+    }
+
     private String getApplicationName() {
         Context context = cordovaActivity.getApplicationContext();
         ApplicationInfo applicationInfo = context.getApplicationInfo();
         int stringId = applicationInfo.labelRes;
         return stringId == 0 ? applicationInfo.nonLocalizedLabel.toString() : context.getString(stringId);
     }
-
 }


### PR DESCRIPTION
### 이슈
- 상황: 안드로이드 권한대응 이슈 대응 2차 qa
- 원인: 안드로이드 권한대응 이슈 대응 2차 qa
- PR 중요도 : 🟠 중요
- PR 기한: 2월 7일 금요일
- 배포예정일: 2월 11일 화요일
- 링크: -

### 작업내용
- Android > 고객앱 애플리케이션 정보 > 앱 권한 항목에 '사진 및 동영상' 권한 노출 ([BUGS-836](https://zimssa.atlassian.net/browse/BUGS-836))
- Android 8 > 이사 RFP 작성 > 사진 등록하기 진행 시 사진 선택 화면 다름 및 사진 선택 시 앱 종료됨 ([BUGS-837](https://zimssa.atlassian.net/browse/BUGS-837))


[BUGS-836]: https://zimssa.atlassian.net/browse/BUGS-836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BUGS-837]: https://zimssa.atlassian.net/browse/BUGS-837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ