### PR TITLE
feat: 안드로이드 권한대응 qa 3차

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -107,10 +107,6 @@
             <activity android:label="@string/multi_app_name" android:name="com.synconset.MultiImageChooserActivity" android:theme="@style/TransparentTheme" />
         </config-file>
 
-        <config-file target="AndroidManifest.xml" parent="/manifest">
-            <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
-        </config-file>
-
         <preference name="ANDROID_SUPPORT_V7_VERSION" default="27.+"/>
         <framework src="com.android.support:appcompat-v7:$ANDROID_SUPPORT_V7_VERSION" />
 


### PR DESCRIPTION
### 이슈
- 상황: 안드로이드 권한대응 qa 3차
- 원인: 안드로이드 권한대응 qa 3차
- PR 중요도 : 🟠 중요 
- PR 기한: 2월 12일 수요일
- 배포예정일: -
- 링크: -

### 작업내용
- [BUGS-841](https://zimssa.atlassian.net/browse/BUGS-841) - [고객앱][2.53.0] 사진 등록 영역 > 등록 가능 개수 -1개의 사진 등록 > 사진 등록 버튼 선택 시 앱종료
- [BUGS-837](https://zimssa.atlassian.net/browse/BUGS-837) - [고객앱][2.53.0] Android 8 > 이사 RFP 작성 > 사진 등록하기 진행 시 사진 선택 화면 다름 및 사진 선택 시 앱 종료됨
- [BUGS-836](https://zimssa.atlassian.net/browse/BUGS-836) - [고객앱][2.53.0] Android > 고객앱 애플리케이션 정보 > 앱 권한 항목에 '사진 및 동영상' 권한 노출

[BUGS-841]: https://zimssa.atlassian.net/browse/BUGS-841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BUGS-837]: https://zimssa.atlassian.net/browse/BUGS-837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BUGS-836]: https://zimssa.atlassian.net/browse/BUGS-836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ